### PR TITLE
fix: Fetch lyrics from the appmobile API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Treat this file as the first source of project context. Search the codebase only
 - `plugin/lyrics.go` implements Navidrome's `GetLyrics` method and delegates to `plugin/musixmatch`.
 - `plugin/musixmatch/` contains Musixmatch-specific desktop API, website search/fetch fallback, normalization, and LRC conversion logic.
 - `plugin/utils/` contains shared config, logging, constants, and PDK HTTP helpers.
-- `plugin/manifest.json` defines Navidrome plugin metadata, HTTP permissions for `apic-desktop.musixmatch.com` and `www.musixmatch.com`, cache permission for the desktop API token, and plugin config schema.
+- `plugin/manifest.json` defines Navidrome plugin metadata, HTTP permissions for `apic-appmobile.musixmatch.com` and `www.musixmatch.com`, cache permission for the desktop API token, and plugin config schema.
 - `just/` and `justfile` define local build, test, install, and cleanup commands.
 - `flake.nix` defines the Nix dev shell and reproducible TinyGo/Nix package build.
 
@@ -34,7 +34,7 @@ Treat this file as the first source of project context. Search the codebase only
 
 ## Key Files
 
-- `plugin/musixmatch/1_desktop.go` implements the unofficial desktop API path at `apic-desktop.musixmatch.com/ws/1.1`, including 10-minute token caching and `macro.subtitles.get` parsing.
+- `plugin/musixmatch/1_desktop.go` implements the unofficial desktop API path at `apic-appmobile.musixmatch.com/ws/1.1`, including 10-minute token caching and `macro.subtitles.get` parsing.
 - `plugin/musixmatch/2_search.go` uses `MusixmatchSearchPageURL`, extracts the search page's `__NEXT_DATA__`, and parses `pageProps.data.openSearch.data.opensearchTrackSearch.body`.
 - `plugin/musixmatch/3_website_scraper.go` uses `nextDataRe` to parse the Musixmatch page and reads `props.pageProps.data.trackInfo.data`.
 - `plugin/musixmatch/4_website_scraper__lyrics_parser.go` converts Musixmatch timestamp totals into LRC tags like `[mm:ss.hh]`.
@@ -78,7 +78,7 @@ Validated during repository onboarding: `go test ./...` passes from `plugin/`, b
 ## Fragility And Gotchas
 
 - This uses an unofficial desktop API first and website scraping as fallback. Musixmatch can block requests, require captcha cookies on the website path, or change API/page/search JSON shapes without warning.
-- `MusixmatchDesktopAPIURL` uses the unofficial desktop endpoint with `app_id=web-desktop-app-v1.0`; if free lookups start failing, check this endpoint and token flow first.
+- `MusixmatchDesktopAPIURL` uses the appmobile endpoint with `app_id=mac-ios-v2.0` and mobile client headers; Musixmatch serves scrambled lyrics to clients it does not recognize, so if free lookups return gibberish, check the host, app id, and headers against a current spicetify/pear-desktop implementation first.
 - Website search parses embedded `__NEXT_DATA__` from `/search?query=...`; it requires a valid `musixmatchUserToken` cookie value and may redirect to auth without one.
 - Search result selection is permissive and does not verify returned artist/title equality after normalization.
 - `slugify` in `plugin/musixmatch/9_utils.go` appears unused.

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,14 +1,14 @@
 {
   "name": "Musixmatch Plugin",
   "author": "Myzel394",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Scrape lyrics from MusixMatch",
   "website": "https://git.nerdvpn.de/Myzel394/navidrome-musixmatch-plugin",
   "permissions": {
     "http": {
       "reason": "To search and fetch lyrics from Musixmatch, and to send opt-in analytics to the maintainer's OpenObserve instance",
       "requiredHosts": [
-        "apic-desktop.musixmatch.com",
+        "apic-appmobile.musixmatch.com",
         "bugs.myzel394.app",
         "www.musixmatch.com"
       ]

--- a/plugin/musixmatch/1_desktop.go
+++ b/plugin/musixmatch/1_desktop.go
@@ -12,7 +12,7 @@ import (
 func fetchLyricsFromDesktopAPI(input lyrics.GetLyricsRequest) (lyrics.GetLyricsResponse, error, *utils.LookupFailure, *utils.LookupSuccess) {
 	utils.LogInfof("desktop API: lookup started duration_filter=%t", input.Track.Duration > 0)
 
-	token, err, failure := desktopUserToken()
+	token, guid, err, failure := desktopUserToken()
 	if err != nil {
 		return lyrics.GetLyricsResponse{}, err, failure, nil
 	}
@@ -20,7 +20,7 @@ func fetchLyricsFromDesktopAPI(input lyrics.GetLyricsRequest) (lyrics.GetLyricsR
 	query := desktopLyricsQuery(input, token)
 
 	var resp desktopResponse
-	err = desktopGet("macro.subtitles.get", query, &resp)
+	err = desktopGet("macro.subtitles.get", query, guid, &resp)
 	if err != nil {
 		utils.LogErrorf("desktop API: lyrics request failed error=%v", err)
 		failure := utils.NewLookupFailure("desktop_macro_request_failed", "desktop_api", err).WithPhase("desktop_lyrics")

--- a/plugin/musixmatch/1_desktop__constants.go
+++ b/plugin/musixmatch/1_desktop__constants.go
@@ -5,8 +5,9 @@ import (
 )
 
 const (
-	desktopAppID       = "web-desktop-app-v1.0"
-	desktopUserAgent   = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.183 Safari/537.36"
+	desktopAppID       = "mac-ios-v2.0"
+	desktopAppVersion  = "10.1.1"
+	desktopClientID    = "Musixmatch/2025120901 CFNetwork/3860.300.31 Darwin/25.2.0"
 	desktopAPISuccess  = 200
 	desktopAPIBlocked  = 401
 	desktopFallbackErr = "desktop API did not return lyrics"

--- a/plugin/musixmatch/1_desktop__token.go
+++ b/plugin/musixmatch/1_desktop__token.go
@@ -1,6 +1,7 @@
 package musixmatch
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -13,6 +14,7 @@ import (
 
 const (
 	desktopTokenCache = "musixmatch_desktop_user_token"
+	desktopGUIDCache  = "musixmatch_desktop_install_guid"
 	desktopTokenTTL   = 10 * time.Minute
 )
 
@@ -20,37 +22,53 @@ type desktopTokenBody struct {
 	UserToken string `json:"user_token"`
 }
 
-func desktopUserToken() (string, error, *utils.LookupFailure) {
-	if token, ok, err := host.CacheGetString(desktopTokenCache); err != nil {
+func desktopUserToken() (string, string, error, *utils.LookupFailure) {
+	token, ok, err := host.CacheGetString(desktopTokenCache)
+	if err != nil {
 		utils.LogErrorf("desktop API token cache read failed: %v", err)
-	} else if ok && token != "" {
+	}
+	guid, guidOK, guidErr := host.CacheGetString(desktopGUIDCache)
+	if guidErr != nil {
+		utils.LogErrorf("desktop API guid cache read failed: %v", guidErr)
+	}
+	if ok && token != "" && guidOK && guid != "" {
 		utils.LogInfof("desktop API: token cache hit")
-		return token, nil, nil
+		return token, guid, nil, nil
 	}
 	utils.LogInfof("desktop API: token cache miss")
 
+	if guid == "" {
+		guid = newDesktopInstallGUID()
+		if guid != "" {
+			if err := host.CacheSetString(desktopGUIDCache, guid, int64(desktopTokenTTL/time.Second)); err != nil {
+				utils.LogErrorf("desktop API guid cache write failed: %v", err)
+			}
+		}
+	}
+
 	query := url.Values{}
 	query.Set("user_language", "en")
+	query.Set("guid", guid)
 
 	var resp desktopResponse
-	err := desktopGet("token.get", query, &resp)
+	err = desktopGet("token.get", query, guid, &resp)
 	if err != nil {
 		utils.LogErrorf("desktop API: token request failed error=%v", err)
 		failure := utils.NewLookupFailure("desktop_token_request_failed", "desktop_api", err).WithPhase("desktop_token")
-		return "", err, failure
+		return "", guid, err, failure
 	}
 	utils.LogInfof("desktop API: token response received status=%d body_bytes=%d", resp.Message.Header.StatusCode, len(resp.Message.Body))
 	if resp.Message.Header.StatusCode == desktopAPIBlocked {
 		pdk.Log(pdk.LogDebug, fmt.Sprintf("desktop API: token response body=%s", string(resp.Message.Body)))
 		err := fmt.Errorf("desktop API returned 401 while fetching token")
 		failure := utils.NewLookupFailure("desktop_token_blocked", "desktop_api", err).WithPhase("desktop_token").WithStatusCode(resp.Message.Header.StatusCode)
-		return "", err, failure
+		return "", guid, err, failure
 	}
 	if resp.Message.Header.StatusCode != desktopAPISuccess {
 		pdk.Log(pdk.LogDebug, fmt.Sprintf("desktop API: token response body=%s", string(resp.Message.Body)))
 		err := fmt.Errorf("desktop API returned status %d while fetching token", resp.Message.Header.StatusCode)
 		failure := utils.NewLookupFailure("desktop_token_status", "desktop_api", err).WithPhase("desktop_token").WithStatusCode(resp.Message.Header.StatusCode)
-		return "", err, failure
+		return "", guid, err, failure
 	}
 
 	var body desktopTokenBody
@@ -58,13 +76,13 @@ func desktopUserToken() (string, error, *utils.LookupFailure) {
 		utils.LogErrorf("desktop API: failed to parse desktop API token body body_bytes=%d error=%v", len(resp.Message.Body), err)
 		pdk.Log(pdk.LogDebug, fmt.Sprintf("desktop API: token response body=%s", string(resp.Message.Body)))
 		failure := utils.NewLookupFailure("desktop_token_parse", "desktop_api", err).WithPhase("desktop_token")
-		return "", err, failure
+		return "", guid, err, failure
 	}
 	if body.UserToken == "" {
 		utils.LogInfof("desktop API: parsed token response token_present=false")
 		err := fmt.Errorf("desktop API returned empty token")
 		failure := utils.NewLookupFailure("desktop_token_empty", "desktop_api", err).WithPhase("desktop_token")
-		return "", err, failure
+		return "", guid, err, failure
 	}
 	utils.LogInfof("desktop API: parsed token response token_present=true")
 
@@ -72,11 +90,24 @@ func desktopUserToken() (string, error, *utils.LookupFailure) {
 		utils.LogErrorf("desktop API token cache write failed: %v", err)
 	}
 
-	return body.UserToken, nil, nil
+	return body.UserToken, guid, nil, nil
+}
+
+func newDesktopInstallGUID() string {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return ""
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }
 
 func desktopInvalidateUserToken() {
 	if err := host.CacheRemove(desktopTokenCache); err != nil {
 		utils.LogErrorf("desktop API token cache remove failed: %v", err)
+	}
+	if err := host.CacheRemove(desktopGUIDCache); err != nil {
+		utils.LogErrorf("desktop API guid cache remove failed: %v", err)
 	}
 }

--- a/plugin/musixmatch/1_desktop__utils.go
+++ b/plugin/musixmatch/1_desktop__utils.go
@@ -28,12 +28,12 @@ func desktopLyricsQuery(input lyrics.GetLyricsRequest, token string) url.Values 
 	return query
 }
 
-func desktopGet(action string, query url.Values, out any) error {
+func desktopGet(action string, query url.Values, guid string, out any) error {
 	query.Set("app_id", desktopAppID)
 	query.Set("t", strconv.FormatInt(time.Now().UnixMilli(), 10))
 
 	endpoint := fmt.Sprintf(utils.MusixmatchDesktopAPIURL, action) + "?" + query.Encode()
-	body, err := _doDesktopGetRequest(endpoint)
+	body, err := _doDesktopGetRequest(endpoint, guid)
 	if err != nil {
 		return err
 	}
@@ -43,16 +43,25 @@ func desktopGet(action string, query url.Values, out any) error {
 	return nil
 }
 
-func _doDesktopGetRequest(endpoint string) ([]byte, error) {
+func _doDesktopGetRequest(endpoint string, guid string) ([]byte, error) {
 	req := pdk.NewHTTPRequest(pdk.MethodGet, endpoint)
-	req.SetHeader("Accept", "application/json")
-	req.SetHeader("Accept-Language", "en")
-	req.SetHeader("Cookie", "AWSELBCORS=0; AWSELB=0")
-	req.SetHeader("User-Agent", desktopUserAgent)
+	for key, value := range desktopAPIHeaders(guid) {
+		req.SetHeader(key, value)
+	}
 
 	resp := req.Send()
 	if resp.Status() != utils.HTTPStatusOK {
 		return resp.Body(), &utils.HTTPError{StatusCode: int(resp.Status())}
 	}
 	return resp.Body(), nil
+}
+
+func desktopAPIHeaders(guid string) map[string]string {
+	return map[string]string{
+		"Accept":            "application/json",
+		"Accept-Language":   "en-US,en;q=0.9",
+		"X-Cookie":          "x-mxm-token-guid=" + guid,
+		"x-mxm-app-version": desktopAppVersion,
+		"X-User-Agent":      desktopClientID,
+	}
 }

--- a/plugin/musixmatch/1_desktop_e2e_test.go
+++ b/plugin/musixmatch/1_desktop_e2e_test.go
@@ -55,10 +55,16 @@ func TestFetchLyricsBirdsOfAFeatherDesktopEndToEnd(t *testing.T) {
 func mockDesktopAPI(t *testing.T) {
 	t.Helper()
 
-	tokenBody := mustGetDesktopTokenBody(t)
-	macroBody := mustGetDesktopMacroBody(t, tokenBody)
+	guid := newDesktopInstallGUID()
+	if guid == "" {
+		t.Fatal("could not generate install guid")
+	}
+	tokenBody := mustGetDesktopTokenBody(t, guid)
+	macroBody := mustGetDesktopMacroBody(t, tokenBody, guid)
 
 	host.CacheMock.On("GetString", desktopTokenCache).Return("", false, nil).Once()
+	host.CacheMock.On("GetString", desktopGUIDCache).Return("", false, nil).Once()
+	host.CacheMock.On("SetString", desktopGUIDCache, mock.AnythingOfType("string"), int64(desktopTokenTTL/time.Second)).Return(nil).Once()
 	host.CacheMock.On("SetString", desktopTokenCache, mock.AnythingOfType("string"), int64(desktopTokenTTL/time.Second)).Return(nil).Once()
 	pdk.PDKMock.On("Log", mock.Anything, mock.Anything).Return()
 	pdk.PDKMock.On("NewHTTPRequest", pdk.MethodGet, mock.MatchedBy(func(endpoint string) bool {
@@ -78,18 +84,18 @@ func mockDesktopAPI(t *testing.T) {
 	})
 }
 
-func mustGetDesktopTokenBody(t *testing.T) []byte {
+func mustGetDesktopTokenBody(t *testing.T, guid string) []byte {
 	t.Helper()
 
-	query := "app_id=" + desktopAppID + "&user_language=en&t=" + strconv.FormatInt(time.Now().UnixMilli(), 10)
-	body, err := realDesktopGetRequest(fmt.Sprintf(utils.MusixmatchDesktopAPIURL, "token.get") + "?" + query)
+	query := "app_id=" + desktopAppID + "&user_language=en&guid=" + guid + "&t=" + strconv.FormatInt(time.Now().UnixMilli(), 10)
+	body, err := realDesktopGetRequest(fmt.Sprintf(utils.MusixmatchDesktopAPIURL, "token.get")+"?"+query, guid)
 	if err != nil {
 		t.Fatalf("failed to fetch desktop token fixture: %v", err)
 	}
 	return body
 }
 
-func mustGetDesktopMacroBody(t *testing.T, tokenBody []byte) []byte {
+func mustGetDesktopMacroBody(t *testing.T, tokenBody []byte, guid string) []byte {
 	t.Helper()
 
 	var tokenResp desktopResponse
@@ -118,23 +124,22 @@ func mustGetDesktopMacroBody(t *testing.T, tokenBody []byte) []byte {
 	query.Set("app_id", desktopAppID)
 	query.Set("t", strconv.FormatInt(time.Now().UnixMilli(), 10))
 
-	body, err := realDesktopGetRequest(fmt.Sprintf(utils.MusixmatchDesktopAPIURL, "macro.subtitles.get") + "?" + query.Encode())
+	body, err := realDesktopGetRequest(fmt.Sprintf(utils.MusixmatchDesktopAPIURL, "macro.subtitles.get")+"?"+query.Encode(), guid)
 	if err != nil {
 		t.Fatalf("failed to fetch desktop macro fixture: %v", err)
 	}
 	return body
 }
 
-func realDesktopGetRequest(endpoint string) ([]byte, error) {
+func realDesktopGetRequest(endpoint string, guid string) ([]byte, error) {
 	client := &http.Client{Timeout: 20 * time.Second}
 	req, err := http.NewRequest(http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("Accept-Language", "en")
-	req.Header.Set("Cookie", "AWSELBCORS=0; AWSELB=0")
-	req.Header.Set("User-Agent", desktopUserAgent)
+	for key, value := range desktopAPIHeaders(guid) {
+		req.Header.Set(key, value)
+	}
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/plugin/utils/constants.go
+++ b/plugin/utils/constants.go
@@ -25,7 +25,7 @@ const (
 const (
 	MusixmatchSearchPageURL = "https://www.musixmatch.com/search?query=%s"
 	MusixmatchFetchPageURL  = "https://www.musixmatch.com/lyrics/%s"
-	MusixmatchDesktopAPIURL = "https://apic-desktop.musixmatch.com/ws/1.1/%s"
+	MusixmatchDesktopAPIURL = "https://apic-appmobile.musixmatch.com/ws/1.1/%s"
 )
 
 const (


### PR DESCRIPTION
Musixmatch serves scrambled lyrics to the apic-desktop endpoint for anonymous tokens. Switch the desktop API path to apic-appmobile with the mac-ios-v2.0 app id and the mobile client headers used by spicetify and pear-desktop (michei69/pear-desktop@052f9bf).

I used AI _(GLM 5.3)_ to edit and implement both the fix and guid logic but I of course reviewed all the changes, tested the lyrics and it works as expected.

<img width="2350" height="776" alt="image" src="https://github.com/user-attachments/assets/877c1e1a-37ee-4ec8-a2f2-128e38dd9175" />
